### PR TITLE
update links and publish

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,12 @@
 See [Microsoft's Change log](https://github.com/microsoft/SEAL/blob/master/CHANGES.md)
 for more details on each SEAL version change.
 
+## Version 5.1.3
+
+Chore:
+
+- Updated new links to Github pages and republish for npm to also have the updated links. No functional changes.
+
 ## Version 5.1.2
 
 Chore:

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -5,7 +5,7 @@ authors:
   given-names: "Nick"
   orcid: "https://orcid.org/0000-0001-7423-158X"
 title: "node-seal, a Homomorphic Encryption library for TypeScript or JavaScript using Microsoft SEAL"
-version: 5.1.2
+version: 5.1.3
 doi: 10.5281/zenodo.1234
 date-released: 2022-03-19
 url: "https://github.com/s0l0ist/node-seal"

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -55,11 +55,11 @@ further defined and clarified by project maintainers.
 ## Enforcement
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
-reported by contacting the project team at info@morfix.io. All
-complaints will be reviewed and investigated and will result in a response that
-is deemed necessary and appropriate to the circumstances. The project team is
-obligated to maintain confidentiality with regard to the reporter of an incident.
-Further details of specific enforcement policies may be posted separately.
+reported by contacting the project author. All complaints will be reviewed and
+investigated and will result in a response that is deemed necessary and
+appropriate to the circumstances. The project team is obligated to maintain
+confidentiality with regard to the reporter of an incident. Further details of
+specific enforcement policies may be posted separately.
 
 Project maintainers who do not follow or enforce the Code of Conduct in good
 faith may face temporary or permanent repercussions as determined by other

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# [node-seal](https://morfix.io) &middot; [![GitHub license](https://img.shields.io/badge/license-MIT-green.svg)](https://github.com/s0l0ist/node-seal/blob/main/LICENSE) [![codecov](https://codecov.io/gh/s0l0ist/node-seal/branch/main/graph/badge.svg)](https://codecov.io/gh/s0l0ist/node-seal) [![npm version](https://badge.fury.io/js/node-seal.svg)](https://www.npmjs.com/package/node-seal) [![FOSSA Status](https://app.fossa.io/api/projects/git%2Bgithub.com%2Fmorfix-io%2Fnode-seal.svg?type=shield)](https://app.fossa.io/projects/git%2Bgithub.com%2Fmorfix-io%2Fnode-seal?ref=badge_shield)
+# [node-seal](https://github.com/s0l0ist/node-seal) &middot; [![GitHub license](https://img.shields.io/badge/license-MIT-green.svg)](https://github.com/s0l0ist/node-seal/blob/main/LICENSE) [![codecov](https://codecov.io/gh/s0l0ist/node-seal/branch/main/graph/badge.svg)](https://codecov.io/gh/s0l0ist/node-seal) [![npm version](https://badge.fury.io/js/node-seal.svg)](https://www.npmjs.com/package/node-seal) [![FOSSA Status](https://app.fossa.io/api/projects/git%2Bgithub.com%2Fmorfix-io%2Fnode-seal.svg?type=shield)](https://app.fossa.io/projects/git%2Bgithub.com%2Fmorfix-io%2Fnode-seal?ref=badge_shield)
 
 node-seal is a homomorphic encryption library for TypeScript or JavaScript.
 
@@ -66,7 +66,7 @@ WebView.
 
 ## Demo
 
-Go to [morfix.io](https://morfix.io)
+Go to [morfix.io](https://s0l0ist.github.io/seal-sandbox/)
 
 This sandbox was built for users to experiment and learn how to use Microsoft
 SEAL featuring node-seal.
@@ -90,7 +90,7 @@ View the latest docs [here](https://s0l0ist.github.io/node-seal)
 
 ## Examples
 
-Check out the [Sandbox](https://morfix.io) to run HE functions and even
+Check out the [Sandbox](https://s0l0ist.github.io/seal-sandbox/) to run HE functions and even
 generate working code!
 
 If you'd rather read an example, take a look [here](FULL-EXAMPLE.md).

--- a/USAGE.md
+++ b/USAGE.md
@@ -256,7 +256,7 @@ const decryptor = seal.Decryptor(context, secretKey)
 ### Functions
 
 We show homomorphic addition, but more functions are available and the code can
-be generated from the [demo](https://morfix.io).
+be generated from the [demo](https://s0l0ist.github.io/seal-sandbox/).
 
 ```javascript
 ////////////////////////

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "node-seal",
-  "version": "5.1.2",
+  "version": "5.1.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "node-seal",
-      "version": "5.1.2",
+      "version": "5.1.3",
       "license": "MIT",
       "devDependencies": {
         "@babel/core": "^7.23.3",

--- a/package.json
+++ b/package.json
@@ -1,16 +1,16 @@
 {
   "name": "node-seal",
-  "version": "5.1.2",
+  "version": "5.1.3",
   "description": "Homomorphic Encryption for TypeScript or JavaScript using Microsoft SEAL",
   "repository": {
     "type": "git",
     "url": "https://github.com/morfix-io/node-seal"
   },
-  "homepage": "https://morfix.io",
+  "homepage": "https://s0l0ist.github.io/seal-sandbox/",
   "author": {
     "name": "Nick Angelou",
-    "email": "accounts@morfix.io",
-    "url": "https://morfix.io"
+    "email": "angelou.nick@gmail.com",
+    "url": "https://s0l0ist.github.io/seal-sandbox/"
   },
   "keywords": [
     "homomorphic",


### PR DESCRIPTION
Updates the repo with updated link that point to the new github page instead of `morfix.io`.